### PR TITLE
Allow to specify number of parallel cores

### DIFF
--- a/apLCMS/R/hybrid.R
+++ b/apLCMS/R/hybrid.R
@@ -161,11 +161,13 @@ hybrid <- function(
   use_observed_range = TRUE,
   recover_min_count = 3,
   intensity_weighted = FALSE,
-  cluster = NULL
+  cluster = parallel::detectCores()
 ) {
-  if (is.null(cluster)) {
-    cluster <- parallel::makeCluster(parallel::detectCores())
+  if (is.numeric(cluster)) {
+    cluster <- parallel::makeCluster(cluster)
     on.exit(parallel::stopCluster(cluster))
+  } else if (!is(cluster, "cluster")) {
+    stop("unsupported value for `cluster` parameter: ", cluster)
   }
 
   # NOTE: side effect (doParallel has no functionality to clean up)
@@ -191,7 +193,8 @@ hybrid <- function(
     peak_estim_method = peak_estim_method,
     component_eliminate = component_eliminate,
     moment_power = moment_power,
-    BIC_factor = BIC_factor
+    BIC_factor = BIC_factor,
+    cluster = cluster
   )
 
   message("**** time correction ****")
@@ -237,7 +240,8 @@ hybrid <- function(
     orig_tol = mz_tol,
     min_bandwidth = min_bandwidth,
     max_bandwidth = max_bandwidth,
-    recover_min_count = recover_min_count
+    recover_min_count = recover_min_count,
+    cluster = cluster
   )
 
   message("**** second round time correction ****")

--- a/apLCMS/R/unsupervised.R
+++ b/apLCMS/R/unsupervised.R
@@ -160,15 +160,13 @@ unsupervised <- function(
   use_observed_range = TRUE,
   recover_min_count = 3,
   intensity_weighted = FALSE,
-  cluster = NULL,
-  cores = NULL
+  cluster = parallel::detectCores()
 ) {
-  if (is.null(cluster)) {
-    if (is.null(cores)) {
-      cores = parallel::detectCores() / 2	# XXX: logical=FALSE does not work on linux, and HT is virtually everywhere nowadays
-    }
-    cluster <- parallel::makeCluster(cores)
+  if (is.numeric(cluster)) {
+    cluster <- parallel::makeCluster(cluster)
     on.exit(parallel::stopCluster(cluster))
+  } else if (!is(cluster, "cluster")) {
+    stop("unsupported value for `cluster` parameter: ", cluster)
   }
 
   # NOTE: side effect (doParallel has no functionality to clean up)


### PR DESCRIPTION
Allow specifying the number of parallel cores to the `hybrid` and `unsupervised` methods.